### PR TITLE
Minor formatting changes for README.md

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-09-24         Dan Cross             <cross@gajendra.net>
+
+	* README.md: Formatting cleanups, change `<tt>` tags to
+	markdown backticks.
+	* sprog.c: Fix all warnings; change to use `getopt(3)`.
+	* pcode.c: Fix all warnings.
+
 2019-09-24         Arnold D. Robbins     <arnold@skeeve.com>
 
 	* makefile: Changes for configurability.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,85 @@
 # The Tenth Edition UNIX Spell Program
 
-This is the <tt>spell</tt> program from the Tenth Edition Research UNIX system.  It has been updated somewhat to compile on modern systems, particularly on Ubuntu Linux.
+This is the `spell` program from the Tenth Edition Research UNIX
+system.  It has been updated somewhat to compile on modern systems,
+particularly on Ubuntu Linux.
 
 ## Installation
 
-The <tt>makefile</tt> and the code have been modified so that installation locations are easily changed; editing the <tt>PREFIX</tt> setting in the <tt>makefile</tt> and then running <tt>make</tt> should be all that's necessary.
+The `makefile` and the code have been modified so that installation
+locations are easily changed; editing the `PREFIX` setting in the
+`makefile` and then running `make` should be all that's necessary.
 
-The program installs itself under the name <tt>v10spell</tt> to avoid conflicts with any native spelling checkers already installed or that might be installed in the future.
+The program installs itself under the name `v10spell` to avoid
+conflicts with any native spelling checkers already installed or
+that might be installed in the future.
 
-After editing the <tt>makefile</tt> (if necessary), it should be enough to do:
+After editing the `makefile` (if necessary), it should be enough
+to do:
 
 	make
 	sudo make install
 
 ## History
 
-The original C version of the UNIX <tt>spell</tt> program was written by Doug McIlroy for V7 UNIX.  The tenth edition version, also by Doug McIlroy, is apparently a descendant of the original one, but able to take advantage of the larger address space available on VAXen as compared to PDP-11s.
+The original C version of the UNIX `spell` program was written by
+Doug McIlroy for V7 UNIX.  The tenth edition version, also by Doug
+McIlroy, is apparently a descendant of the original one, but able
+to take advantage of the larger address space available on VAXen
+as compared to PDP-11s.
 
-Doug McIlroy published a paper on the original UNIX <tt>spell</tt> in IEEE Transactions on Communications. It's available from his [home page](https://www.cs.dartmouth.edu/~doug/spell.pdf).
+Doug McIlroy published a paper on the original UNIX `spell` in IEEE
+Transactions on Communications. It's available from his
+[home page](https://www.cs.dartmouth.edu/~doug/spell.pdf).
 
 In private mail to me, Doug says:
 
-> By the 10th edition, the word list no longer needed to be compressed, and "part-of-speech" affixability codes had been added, thanks to work of Ruby Jane Elliott. The codes cut down on the acceptance of silly derivatives.
+> By the 10th edition, the word list no longer needed to be compressed,
+> and "part-of-speech" affixability codes had been added, thanks to
+> work of Ruby Jane Elliott.  The codes cut down on the acceptance of
+> silly derivatives.
 
-However, this version still uses the compressed dictionaries. He likely has a newer version of the code.
+However, this version still uses the compressed dictionaries. He
+likely has a newer version of the code.
 
 ## Changes Made
 
-The original code looks to have been written such that it would compile for both C and C++. I have removed the C++ bits and gone for straight C. Along the way, I fixed a core dump issue in the main program that apparently didn't happen on the Research VAX systems.
+The original code looks to have been written such that it would
+compile for both C and C++.  I have removed the C++ bits and gone
+for straight C.  Along the way, I fixed a core dump issue in the
+main program that apparently didn't happen on the Research VAX
+systems.
 
-In addition, I've made use of modern headers and library bits that are standard, such as <tt>strdup()</tt> and <tt>EXIT_FAILURE</tt> and <tt>EXIT_SUCCESS</tt>.  In what I think are all the appropriate cases I've replaced <tt>0</tt> with either <tt>NULL</tt> or <tt>'\0'</tt>.
+In addition, I've made use of modern headers and library bits that
+are standard, such as `strdup()` and `EXIT_FAILURE` and `EXIT_SUCCESS`.
+In what I think are all the appropriate cases I've replaced `0`
+with either `NULL` or `'\0'`.
 
-The original code was very sparing on white space; this seems to have been Doug's personal style. I have added more space to make the code a little bit easier on the eyes. (At least, on my eyes.)
+The original code was very sparing on white space; this seems to
+have been Doug's personal style.  I have added more space to make
+the code a little bit easier on the eyes.  (At least, on my eyes.)
 
-The shell script driver no longer uses <tt>deroff</tt> or <tt>delatex</tt>. Neither of these is standard on Linux systems, and I am not aware of a version of <tt>deroff</tt> that understands the extended facilities of GNU <tt>troff</tt>.  Anyone who wants to help repair these deficiencies should be in touch.
+The shell script driver no longer uses `deroff` or `delatex`.  Neither
+of these is standard on Linux systems, and I am not aware of a
+version of `deroff` that understands the extended facilities of GNU
+`troff`.  Anyone who wants to help repair these deficiencies should
+be in touch.
 
-The original code is tagged with <tt>v10-code-from-TUHS</tt>; check out that tag if you want to see it.
+The original code is tagged with `v10-code-from-TUHS`; check out
+that tag if you want to see it.
 
 ## Oddities
 
-The <tt>amspell</tt> and <tt>brspell</tt> files differ slightly from those found in the tenth edition sources tarball. I'm not sure why. Nonetheless, they work ok. (Or at least, the <tt>amspell</tt> one does. I have not tested British spelling.)
+The `amspell` and `brspell` files differ slightly from those found
+in the tenth edition sources tarball.  I'm not sure why.  Nonetheless,
+they work ok.  (Or at least, the `amspell` one does.  I have not
+tested British spelling.)
 
-Also, it seems that "prioritize" appears in both the standard list and in the list of American words. It likely should be removed from the standard list, but I haven't done that yet. (Doug McIlroy - if you have anything to say about this, please let me know.)
+Also, it seems that "prioritize" appears in both the standard list
+and in the list of American words.  It likely should be removed from
+the standard list, but I haven't done that yet.  (Doug McIlroy - if
+you have anything to say about this, please let me know.)
 
 #### Last Updated
+
 Tue Sep 24 19:59:22 IDT 2019

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ MANDIR = $(PREFIX)/share/man/man1
 
 HFILES = code.h
 
-CFLAGS = -O -DLIBDIR='"$(LIBDIR)/"'
+CFLAGS = -Wall -O -DLIBDIR='"$(LIBDIR)/"'
 
 all:	sprog brspell amspell
 

--- a/pcode.c
+++ b/pcode.c
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -124,38 +123,38 @@ Class	codea[]  =
 {
 	{ "a", ADJ },
 	{ "adv", ADV },
-	NULL
+	{ NULL, 0 },
 };
 Class	codec[] =
 {
 	{ "comp", COMP },
-	NULL
+	{ NULL, 0 },
 };
 Class	coded[] =
 {
 	{ "d", DONT_TOUCH},
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codee[] =
 {
 	{ "ed",	ED },
 	{ "er", ACTOR },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codei[] =
 {
 	{ "in", IN },
 	{ "ion", ION },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codem[] =
 {
 	{ "man", MAN },
 	{ "ms", MONO },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	coden[] =
@@ -163,18 +162,18 @@ Class	coden[] =
 	{ "n", NOUN },
 	{ "na", N_AFFIX },
 	{ "nopref", NOPREF },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codep[] =
 {
 	{ "pc", PROP_COLLECT },
-	NULL
+	{ NULL, 0 },
 };
 Class	codes[] =
 {
 	{ "s", STOP },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codev[] =
@@ -182,18 +181,18 @@ Class	codev[] =
 	{ "v", VERB },
 	{ "va", V_AFFIX },
 	{ "vi", V_IRREG },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codey[] =
 {
 	{ "y", _Y },
-	NULL
+	{ NULL, 0 },
 };
 
 Class	codez[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Class*	codetab[] =
 {
@@ -332,7 +331,7 @@ pdict(void)
 		c = (1 << 15) | (j << 11) | encode;
 		sput(c);
 		count += 2;
-		for (thisword = word + j; c = *thisword; thisword++) {
+		for (thisword = word + j; (c = *thisword) != '\0'; thisword++) {
 			putchar(c);
 			count++;
 		}

--- a/sprog.c
+++ b/sprog.c
@@ -1,4 +1,3 @@
-
 #include "code.h"
 
 #include <stdio.h>
@@ -10,7 +9,6 @@
 #include <fcntl.h>
 #include <locale.h>
 
-#define isvowel(c)	voweltab[c]
 #define pair(a, b)	(((a) << 8) | (b))
 #define DLEV		2
 #define DSIZ		40
@@ -72,7 +70,7 @@ typedef struct	Suftab
 
 Suftab	staba[] = {
 	{ "aibohp", subst, 1, "-e+ia", "", NOUN, NOUN },
-	NULL
+	{ NULL, 0 },
 };
 
 Suftab	stabc[] =
@@ -86,13 +84,13 @@ Suftab	stabc[] =
 	{ "cigol", i_to_y, 1, "-y+ic", "", NOUN, ADJ  },
 	{ "cimono", i_to_y, 1, "-y+ic", "", NOUN, ADJ  },
 	{ "cibohp", subst, 1, "-e+ic", "", NOUN, ADJ  },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabd[] =
 {
 	{ "de", strip, 1, "", "+d", ED, ADJ |COMP, i_to_y, 2, "-y+ied", "+ed" },
 	{ "dooh", ily, 4, "-y+ihood", "+hood", NOUN | ADV, NOUN },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabe[] =
 {
@@ -105,7 +103,7 @@ Suftab	stabe[] =
 	{ "evi", subst, 0, "-ion+ive", "", N_AFFIX | V_AFFIX, NOUN | N_AFFIX| ADJ },
 	{ "ezi", CCe, 3, "-e+ize", "+ize", N_AFFIX|ADJ , V_AFFIX | VERB |ION | COMP },
 	{ "ekil", strip, 4, "", "+like", N_AFFIX , ADJ },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabg[] =
 {
@@ -113,7 +111,7 @@ Suftab	stabg[] =
 	{ "gnikam", strip, 6, "", "+making", NOUN, NOUN },
 	{ "gnipeek", strip, 7, "", "+keeping", NOUN, NOUN },
 	{ "gni", CCe, 3, "-e+ing", "+ing", V_IRREG , ADJ|ED|NOUN },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabl[] =
 {
@@ -122,14 +120,14 @@ Suftab	stabl[] =
 	{ "latnem", strip, 2, "", "+al", N_AFFIX, ADJ },
 	{ "lanoi", strip, 2, "", "+al", N_AFFIX, ADJ|NOUN },
 	{ "luf", ily, 3, "-y+iful", "+ful", N_AFFIX, ADJ | NOUN },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabm[] =
 {
 		/* congregational + ism */
 	{ "msi", CCe, 3, "-e+ism", "ism", N_AFFIX|ADJ, NOUN },
 	{ "margo", subst, -1, "-ph+m", "", NOUN, NOUN },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabn[] =
 {
@@ -142,12 +140,12 @@ Suftab	stabn[] =
 	{ "na", an, 1, "", "+n", NOUN|PROP_COLLECT, NOUN | N_AFFIX },
 	{ "nemow", strip, 5, "", "+women", MAN, PROP_COLLECT },
 	{ "nem", strip, 3, "", "+man", MAN, PROP_COLLECT },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabp[] =
 {
 	{ "pihs", strip, 4, "", "+ship", NOUN|PROP_COLLECT, NOUN| N_AFFIX },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabr[] =
 {
@@ -159,7 +157,7 @@ Suftab	stabr[] =
 	{ "rota", tion, 2, "-e+or", "", ION, NOUN| N_AFFIX|_Y },
 	{ "rotc", tion, 2, "", "+or", ION, NOUN| N_AFFIX },
 	{ "rotp", tion, 2, "", "+or", ION, NOUN| N_AFFIX },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabs[] =
 {
@@ -168,7 +166,7 @@ Suftab	stabs[] =
 	{ "se", s, 1, "", "+s", NOUN | V_IRREG, DONT_TOUCH , 	es, 2, "-y+ies", "+es" },
 	{ "s'", s, 2, "", "+'s", PROP_COLLECT | NOUN, DONT_TOUCH  },
 	{ "s", s, 1, "", "+s", NOUN | V_IRREG, DONT_TOUCH   },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabt[] =
 {
@@ -176,7 +174,7 @@ Suftab	stabt[] =
 	{ "tse", strip, 2, "", "+st", EST, DONT_TOUCH, 	i_to_y, 3, "-y+iest", "+est"  },
 	{ "tsigol", i_to_y, 2, "-y+ist", "", N_AFFIX, NOUN | N_AFFIX },
 	{ "tsi", CCe, 3, "-e+ist", "+ist", N_AFFIX|ADJ, NOUN | N_AFFIX|COMP },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	staby[] =
 {
@@ -190,11 +188,11 @@ Suftab	staby[] =
 	{ "yl", ily, 2, "-y+ily", "+ly", ADJ, ADV|COMP },
 	{ "yrtem", subst, 0, "-er+ry", "", NOUN, NOUN | N_AFFIX },
 	{ "y", CCe, 1, "-e+y", "+y", _Y, ADJ|COMP },
-	NULL
+	{ NULL, 0 },
 };
 Suftab	stabz[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Suftab*	suftab[] =
 {
@@ -230,43 +228,43 @@ Ptab	ptaba[] =
 {
 	{ "anti", 0 },
 	{ "auto", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabb[] =
 {
 	{ "bio", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabc[] =
 {
 	{ "counter", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabd[] =
 {
 	{ "dis", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabe[] =
 {
 	{ "electro", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabf[] =
 {
 	{ "femto", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabg[] =
 {
 	{ "geo", 0 },
 	{ "giga", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabh[] =
 {
 	{ "hyper", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabi[] =
 {
@@ -277,20 +275,20 @@ Ptab	ptabi[] =
 	{ "in", IN },
 	{ "ir", IN },
 	{ "iso", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabj[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabk[] =
 {
 	{ "kilo", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabl[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabm[] =
 {
@@ -304,20 +302,20 @@ Ptab	ptabm[] =
 	{ "mis", 0 },
 	{ "mono", 0 },
 	{ "multi", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabn[] =
 {
 	{ "nano", 0 },
 	{ "neuro", 0 },
 	{ "non", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabo[] =
 {
 	{ "out", 0 },
 	{ "over", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabp[] =
 {
@@ -328,18 +326,18 @@ Ptab	ptabp[] =
 	{ "pre", 0 },
 	{ "pseudo", 0 },
 	{ "psycho", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabq[] =
 {
 	{ "quasi", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabr[] =
 {
 	{ "radio", 0 },
 	{ "re", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabs[] =
 {
@@ -347,40 +345,40 @@ Ptab	ptabs[] =
 	{ "stereo", 0 },
 	{ "sub", 0 },
 	{ "super", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabt[] =
 {
 	{ "tele", 0 },
 	{ "thermo", 0 },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabu[] =
 {
 	{ "ultra", 0 },
 	{ "under", 0 }, 	/*must precede un*/
 	{ "un", IN },
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabv[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabw[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabx[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptaby[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 Ptab	ptabz[] =
 {
-	NULL
+	{ NULL, 0 },
 };
 
 Ptab*	preftab[] =
@@ -447,66 +445,56 @@ main(int argc, char *argv[])
 {
 	char *ep, *cp;
 	char *dp;
-	int j, i, c;
+	int c;
 	int low = 0;
 	Bits h;
 
 	setlocale(LC_ALL, "C");
 
-	for (i = 0; (c = "aeiouyAEIOUY"[i]) != '\0'; i++)
-		voweltab[c] = true;
+	const char *vs = "aeiouyAEIOUY";
+	for (const char *v = vs; *v != '\0'; v++)
+		voweltab[(int)*v] = true;
 
-	while (argc > 1) {
-		if (argv[1][0] != '-')
+	while ((c = getopt(argc, argv, "bCcvxf:")) != -1) {
+		switch (c) {
+		default:
+			fprintf(stderr, "usage: spell [-bcCvx] [-f file]\n");
+			exit(EXIT_FAILURE);
+
+		case 'b':
+			ise();
+			if (! fflag)
+				codefile = brfile;
 			break;
-		for (i = 1; c = argv[1][i]; i++) {
-			switch (c) {
-			default:
-				fprintf(stderr, "usage: spell [-bcCvx] [-f file]\n");
-				exit(EXIT_FAILURE);
 
-			case 'b':
-				ise();
-				if (! fflag)
-					codefile = brfile;
-				continue;
+		case 'C':
+			vflag++;
+		case 'c':
+			setbuf(stdout, 0);
+			cflag++;
+			break;
 
-			case 'C':
-				vflag++;
-			case 'c':
-				setbuf(stdout, 0);
-				cflag++;
-				continue;
+		case 'v':
+			vflag++;
+			break;
 
-			case 'v':
-				vflag++;
-				continue;
+		case 'x':
+			xflag++;
+			break;
 
-			case 'x':
-				xflag++;
-				continue;
-
-			case 'f':
-				if (argc <= 2) {
-					fprintf(stderr, "spell: -f requires another argument\n");
-					exit(EXIT_FAILURE);
-				}
-				argv++;
-				argc--;
-				fflag++;
-				codefile = argv[1];
-				goto brk;
-			}
+		case 'f':
+			fflag++;
+			codefile = optarg;
+			break;
 		}
-	brk:
-		argv++;
-		argc--;
 	}
-	readdict(codefile);
+	argc -= optind;
+	argv += optind;
 	if (argc > 1) {
 		fprintf(stderr, "usage: spell [-bcvx] [-f file]\n");
 		exit(EXIT_FAILURE);
 	}
+	readdict(codefile);
 	for (;;) {
 	loop:
 		affix[0] = '\0';
@@ -516,30 +504,30 @@ main(int argc, char *argv[])
 				runout(original);
 				goto loop;
 			}
-			j = getchar();
-			if (j == EOF)
+			c = getchar();
+			if (c == EOF)
 				exit(EXIT_SUCCESS);
 			// Input must be one word per line!
-			if (j != '\n')
-				*ep = j;
+			if (c != '\n')
+				*ep = c;
 			else {
 				*ep = '\0';
 				break;
 			}
 		}
 		low = 0;
-		for (ep = word, dp = original; (j = *dp) != '\0'; ep++, dp++) {
-			if (islower(j))
+		for (ep = word, dp = original; (c = *dp) != '\0'; ep++, dp++) {
+			if (islower(c))
 				low++;
 			if (ep >= word + sizeof(word) - 1)
 				break;
-			*ep = j;
+			*ep = c;
 		}
 		*ep = '\0';
 
 		h = ~STOP;
-		if (word[1] == '\0' && isalnum(word[0]) ||
-		   isdigit(word[0]) && ordinal())
+		if ((word[1] == '\0' && isalnum(word[0])) ||
+		    (isdigit(word[0]) && ordinal()))
 			goto check;
 
 		h = 0;
@@ -548,15 +536,15 @@ main(int argc, char *argv[])
 				*dp = tolower(*cp);
 		if (! h) {
 			for (;;) {	/* at most twice */
-				if (h = trypref(ep, ".", 0, ALL|STOP|DONT_TOUCH))
+				if ((h = trypref(ep, ".", 0, ALL|STOP|DONT_TOUCH)) != 0)
 					break;
-				if (h = trysuff(ep, 0, ALL|STOP|DONT_TOUCH))
+				if ((h = trysuff(ep, 0, ALL|STOP|DONT_TOUCH)) != 0)
 					break;
 				if (! isupper(word[0]))
 					break;
 				cp = original;
 				dp = word;
-				for (; *dp = *cp++; dp++) {
+				for (; (*dp = *cp++) != '\0'; dp++) {
 					if (! low)
 						*dp = tolower(*dp);
 				}
@@ -580,6 +568,12 @@ main(int argc, char *argv[])
 
 	/* NOTREACHED */
 	return EXIT_SUCCESS;
+}
+
+bool
+isvowel(int c)
+{
+	return voweltab[c];
 }
 
 /*	strip exactly one suffix and do
@@ -626,11 +620,11 @@ trysuff(char* ep, int lev, int flag)
 Bits
 nop(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref ep
-#pragma ref d
-#pragma ref a
-#pragma ref lev
-#pragma ref flag
+	(void)ep;
+	(void)d;
+	(void)a;
+	(void)lev;
+	(void)flag;
 	return 0;
 }
 
@@ -659,7 +653,7 @@ cstrip(char* ep, char* d, char* a, int lev, int flag)
 Bits
 strip(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref d
+	(void)d;
 	Bits h = trypref(ep, a, lev, flag);
 
 	if (Set(h, MONO) && isvowel(*ep) && isvowel(ep[-2]))
@@ -702,7 +696,7 @@ s(char* ep, char* d, char* a, int lev, int flag)
 Bits
 an(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref d
+	(void)d;
 	if (! isupper(*word))	/* must be proper name */
 		return 0;
 	return trypref(ep, a, lev, flag);
@@ -711,7 +705,7 @@ an(char* ep, char* d, char* a, int lev, int flag)
 Bits
 ize(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref a
+	(void)a;
 	int temp = ep[-1];
 	Bits h;
 
@@ -724,7 +718,7 @@ ize(char* ep, char* d, char* a, int lev, int flag)
 Bits
 y_to_e(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref a
+	(void)a;
 	Bits h;
 	int  temp;
 
@@ -810,7 +804,7 @@ es(char* ep, char* d, char* a, int lev, int flag)
 Bits
 subst(char* ep, char* d, char* a, int lev, int flag)
 {
-#pragma ref a
+	(void)a;
 	char *u, *t;
 	Bits h;
 
@@ -876,7 +870,7 @@ CCe(char* ep, char* d, char* a, int lev, int flag)
 		if (isvowel(ep[-2]))
 			break;
 	case 'u':
-		if (h = y_to_e(ep, d, a, lev, flag))
+		if ((h = y_to_e(ep, d, a, lev, flag)) != 0)
 			return h;
 		if (! (ep[-2] == 'n' && ep[-1] == 'g'))
 			return 0;
@@ -952,7 +946,7 @@ trypref(char* ep, char* a, int lev, int flag)
 		deriv[lev].mesg = a;
 		deriv[lev].type = (*a =='.' ? NONE : SUFF);
 	}
-	if (h = tryword(word, ep, lev, flag)) {
+	if ((h = tryword(word, ep, lev, flag)) != 0) {
 		if (Set(h, flag & ~MONO) && (flag & MONO) <= Set(h, MONO))
 			return h;
 		h = 0;
@@ -963,7 +957,7 @@ trypref(char* ep, char* a, int lev, int flag)
 		deriv[lev + 1].mesg = pp;
 		deriv[lev + 1].type = 0;
 	}
-	while (tp = lookuppref(&bp, ep)) {
+	while ((tp = lookuppref(&bp, ep)) != NULL) {
 		*pp++ = '+';
 		cp = tp->s;
 		while (pp < space + sizeof(space) && (*pp = *cp++) != '\0')

--- a/sprog.c
+++ b/sprog.c
@@ -559,7 +559,7 @@ main(int argc, char *argv[])
 				putchar('+');
 			else 
 				putchar('0' + (suffcount > 0) +
-				   (prefcount > 4 ? 8 : 2 * prefcount));
+				    (prefcount > 4 ? 8 : 2 * prefcount));
 		} else if (! h || Set(h, STOP))
 			printf("%s\n", original);
 		else if (affix[0] != '\0' && affix[0] != '.')


### PR DESCRIPTION
Just to make this slightly easier to read in the terminal:
add line breaks and replace HTML-style <tt> tags to back
ticks, which expand to <code> sequences.

Signed-off-by: Dan Cross <cross@gajendra.net>