### PR TITLE
Avoid UB by using unsigned types for hashes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-07-11         Dan Cross             <cross@gajendra.net>
+
+	* Avoid UB by using unsigned types for hashes
+
 2019-12-06         Arnold D. Robbins     <arnold@skeeve.com>
 
 	* code.h (code2str): New function.

--- a/pcode.c
+++ b/pcode.c
@@ -13,8 +13,8 @@
 	octal <tab> word
  */
 
-typedef int32_t Bits;
-typedef	struct	Dict	Dict;
+typedef uint32_t Bits;
+typedef	struct Dict Dict;
 struct	Dict
 {
 	char*	word;

--- a/sprog.c
+++ b/sprog.c
@@ -14,9 +14,9 @@
 #define DLEV		2
 #define DSIZ		40
 
-typedef	int32_t	Bits;
-typedef unsigned char uchar;
-#define	Set(h, f)	((int32_t)(h) & (f))
+typedef	uint32_t	Bits;
+typedef unsigned char	uchar;
+#define	Set(h, f)	((Bits)(h) & (f))
 
 Bits 	nop(char*, char*, char*, int, int);
 Bits 	strip(char*, char*, char*, int, int);


### PR DESCRIPTION
Use unsigned types for hash arithemtic, since e.g.
signed overflow is undefined behavior in C.

Signed-off-by: Dan Cross <cross@gajendra.net>